### PR TITLE
Remove 'tailor this post' from archives

### DIFF
--- a/includes/helpers/helpers-links.php
+++ b/includes/helpers/helpers-links.php
@@ -18,6 +18,11 @@ if ( ! function_exists( 'tailor_admin_bar_edit_link' ) ) {
 	 * @param WP_Admin_Bar $wp_admin_bar
 	 */
 	function tailor_admin_bar_edit_link( $wp_admin_bar ) {
+		
+		// Do not display link on archives/ homepage etc
+		if ( ! is_singular() ) {
+			return;
+		}
 
 		if ( tailor()->is_canvas() ) {
 			return;


### PR DESCRIPTION
Currently Tailor displays the 'tailor this post' message on all pages, However I don't think this is clear. Removing it from archives would remove confusion over what will be tailored.