### PR TITLE
Small background images do not have the 'thumbnail' size.

### DIFF
--- a/assets/js/dist/sidebar.js
+++ b/assets/js/dist/sidebar.js
@@ -2296,13 +2296,7 @@ ImageControl = AbstractControl.extend( {
         var sizes = attachment.get( 'sizes' );
 
         this.setSettingValue( attachment.get( 'id' ) );
-
-        if ( sizes.hasOwnProperty( 'medium' ) ) {
-            this.updateThumbnail( sizes.medium.url );
-        }
-        else {
-            this.updateThumbnail( sizes.thumbnail.url );
-        }
+        this.updateThumbnail( sizes );
     },
 
     /**
@@ -2310,9 +2304,19 @@ ImageControl = AbstractControl.extend( {
      *
      * @since 1.0.0
      *
-     * @param url
+     * @param sizes
      */
-    updateThumbnail : function( url ) {
+    updateThumbnail : function( sizes ) {
+        var url;
+        if ( sizes.hasOwnProperty( 'medium' ) ) {
+            url = sizes.medium.url;
+        }else if( sizes.hasOwnProperty( 'thumbnail' ) ){
+            url = sizes.thumbnail.url;
+        }else if( sizes.hasOwnProperty( 'full' ) ){
+            url = sizes.full.url; // small images do not have thumbnail generated
+        }else{
+            return; // invalid sizes
+        }
         this.ui.thumbnails
             .removeClass( 'is-loading' )
             .html( '<li class="thumbnail"><img src="' + url + '"/></li>' );
@@ -2342,23 +2346,13 @@ ImageControl = AbstractControl.extend( {
             var sizes = attachment.get( 'sizes' );
 
             if ( sizes ) {
-                if ( sizes.hasOwnProperty( 'medium' ) ) {
-                    this.updateThumbnail( sizes.medium.url );
-                }
-                else {
-                    this.updateThumbnail( sizes.thumbnail.url );
-                }
+                this.updateThumbnail( sizes );
             }
             else {
                 attachment.fetch( {
                     success : function() {
                         sizes = attachment.get( 'sizes' );
-                        if ( sizes.hasOwnProperty( 'medium' ) ) {
-                            control.updateThumbnail( sizes.medium.url );
-                        }
-                        else {
-                            control.updateThumbnail( sizes.thumbnail.url );
-                        }
+                        control.updateThumbnail( sizes );
                     }
                 } );
             }

--- a/assets/js/src/components/controls/image.js
+++ b/assets/js/src/components/controls/image.js
@@ -85,13 +85,7 @@ ImageControl = AbstractControl.extend( {
         var sizes = attachment.get( 'sizes' );
 
         this.setSettingValue( attachment.get( 'id' ) );
-
-        if ( sizes.hasOwnProperty( 'medium' ) ) {
-            this.updateThumbnail( sizes.medium.url );
-        }
-        else {
-            this.updateThumbnail( sizes.thumbnail.url );
-        }
+        this.updateThumbnail( sizes );
     },
 
     /**
@@ -99,9 +93,19 @@ ImageControl = AbstractControl.extend( {
      *
      * @since 1.0.0
      *
-     * @param url
+     * @param sizes
      */
-    updateThumbnail : function( url ) {
+    updateThumbnail : function( sizes ) {
+        var url;
+        if ( sizes.hasOwnProperty( 'medium' ) ) {
+            url = sizes.medium.url;
+        }else if( sizes.hasOwnProperty( 'thumbnail' ) ){
+            url = sizes.thumbnail.url;
+        }else if( sizes.hasOwnProperty( 'full' ) ){
+            url = sizes.full.url; // small images do not have thumbnail generated
+        }else{
+            return; // invalid sizes
+        }
         this.ui.thumbnails
             .removeClass( 'is-loading' )
             .html( '<li class="thumbnail"><img src="' + url + '"/></li>' );
@@ -131,23 +135,13 @@ ImageControl = AbstractControl.extend( {
             var sizes = attachment.get( 'sizes' );
 
             if ( sizes ) {
-                if ( sizes.hasOwnProperty( 'medium' ) ) {
-                    this.updateThumbnail( sizes.medium.url );
-                }
-                else {
-                    this.updateThumbnail( sizes.thumbnail.url );
-                }
+                this.updateThumbnail( sizes );
             }
             else {
                 attachment.fetch( {
                     success : function() {
                         sizes = attachment.get( 'sizes' );
-                        if ( sizes.hasOwnProperty( 'medium' ) ) {
-                            control.updateThumbnail( sizes.medium.url );
-                        }
-                        else {
-                            control.updateThumbnail( sizes.thumbnail.url );
-                        }
+                        control.updateThumbnail( sizes );
                     }
                 } );
             }

--- a/includes/helpers/helpers-elements.php
+++ b/includes/helpers/helpers-elements.php
@@ -1148,13 +1148,12 @@ if ( ! function_exists( 'tailor_css_presets' ) ) {
 			$background_image_info = wp_get_attachment_image_src( trim( $atts['background_image'] ), 'full' );
 			$background_image_src = $background_image_info[0];
 
-			if ( array_key_exists( 'background_color', $atts ) && ! empty( $atts['background_color'] ) && ! in_array( 'background_color', $excluded_control_types ) && false !== strpos( $atts['background_color'], 'rgba' ) ) {
+			if ( array_key_exists( 'background_color', $atts ) && ! empty( $atts['background_color'] ) && ! in_array( 'background_color', $excluded_control_types ) ) {
 				$css_rules[] = array(
 					'selectors'         =>  array(),
 					'declarations'      =>  array(
 						'background'        =>  esc_attr(
-							"linear-gradient( {$atts['background_color']},{$atts['background_color']} ),
-							url({$background_image_src}) center center no-repeat"
+							"{$atts['background_color']} url({$background_image_src}) center center no-repeat"
 						),
 					),
 				);

--- a/includes/helpers/helpers-elements.php
+++ b/includes/helpers/helpers-elements.php
@@ -1148,15 +1148,30 @@ if ( ! function_exists( 'tailor_css_presets' ) ) {
 			$background_image_info = wp_get_attachment_image_src( trim( $atts['background_image'] ), 'full' );
 			$background_image_src = $background_image_info[0];
 
-			if ( array_key_exists( 'background_color', $atts ) && ! empty( $atts['background_color'] ) && ! in_array( 'background_color', $excluded_control_types ) ) {
-				$css_rules[] = array(
-					'selectors'         =>  array(),
-					'declarations'      =>  array(
-						'background'        =>  esc_attr(
-							"{$atts['background_color']} url({$background_image_src}) center center no-repeat"
+			if ( array_key_exists( 'background_color', $atts ) && ! empty( $atts['background_color'] ) && ! in_array( 'background_color', $excluded_control_types )) {
+				if( false !== strpos( $atts['background_color'], 'rgba' ) ) {
+					// this allows you to "tint" your background image with a transparent color
+					// see: https://css-tricks.com/tinted-images-multiple-backgrounds/
+					$css_rules[] = array(
+						'selectors'    => array(),
+						'declarations' => array(
+							'background' => esc_attr(
+								"linear-gradient( {$atts['background_color']}, {$atts['background_color']} ), 
+								url({$background_image_src}) center center no-repeat"
+							),
 						),
-					),
-				);
+					);
+				}else{
+					// otherwise we assume it's going to be a transparent image over a solid background color
+					$css_rules[] = array(
+						'selectors'    => array(),
+						'declarations' => array(
+							'background' => esc_attr(
+								"{$atts['background_color']} url({$background_image_src}) center center no-repeat"
+							),
+						),
+					);
+				}
 			}
 			else {
 				$css_rules[] = array(

--- a/includes/helpers/helpers-elements.php
+++ b/includes/helpers/helpers-elements.php
@@ -869,12 +869,13 @@ if ( ! function_exists( 'tailor_control_presets' ) ) {
 			'background_size'       =>  array(
 				'setting'               =>  array(
 					'sanitize_callback'     =>  'tailor_sanitize_text',
-					'default'               =>  'cover',
+					'default'               =>  'auto',
 				),
 				'control'               =>  array(
 					'label'                 =>  __( 'Background size', 'tailor' ),
 					'type'                  =>  'select',
 					'choices'               =>  array(
+						'auto'                 =>  __( 'Normal', 'tailor' ),
 						'cover'                 =>  __( 'Cover', 'tailor' ),
 						'contain'               =>  __( 'Contain', 'tailor' ),
 					),


### PR DESCRIPTION
Also need some sort of 'default' background size option that isn't Cover or Contain, so that we can repeat background images correctly.

Here's an example small background image that I was trying to make repeating on a Row/Section and can be used to trigger this javascript error.

![grey-tile](https://cloud.githubusercontent.com/assets/543073/16719914/963bd966-4773-11e6-8bfd-c3bfd8b14238.jpg)

Don't feel you have to merge my shitty code, just see where the bug is and implement your own better fix :) :+1: 