### PR TITLE
This won't raise notice error with WP_DEBUG

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -389,7 +389,7 @@ class Tailor_Settings {
 
 			tailor_partial( 'admin/field', $args['type'], $args );
 
-			if ( $args['description'] ) {
+			if ( isset($args['description']) ) {
 				printf( '<p class="description">%s</p>', $args['description'] );
 			} ?>
 


### PR DESCRIPTION
Checking with isset(), it does not rises PHP error. Otherwise, when using with WP_DEBUG it causes ugly output after each settings item, which doesn't have description.