### PR TITLE
Fix callback function name for oEmbed wrapping

### DIFF
--- a/includes/helpers/helpers-markup.php
+++ b/includes/helpers/helpers-markup.php
@@ -301,5 +301,5 @@ if ( ! function_exists( 'tailor_responsive_wrap_oembed_dataparse' ) ) {
 		return "<div class=\"{$class_name}\">{$html}</div>";
 	}
 
-	add_filter( 'oembed_dataparse','responsive_wrap_oembed_dataparse', 10, 2 );
+	add_filter( 'oembed_dataparse','tailor_responsive_wrap_oembed_dataparse', 10, 2 );
 }


### PR DESCRIPTION
The name of the callback function specified in the `add_filter()` hook is incorrect.

This cause the embedded media to fail to show.