### PR TITLE
Add edit link above content editor

### DIFF
--- a/includes/helpers/helpers-links.php
+++ b/includes/helpers/helpers-links.php
@@ -92,7 +92,7 @@ if ( ! function_exists( 'tailor_content_editor_link' ) ) {
      */
     function tailor_content_editor_link() {
 
-		if ( tailor()->is_canvas() ) {
+		if ( tailor()->is_canvas() || tailor()->is_tailoring() ) {
 			return;
 		}
 

--- a/includes/helpers/helpers-links.php
+++ b/includes/helpers/helpers-links.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'tailor_admin_bar_edit_link' ) ) {
 	 * @param WP_Admin_Bar $wp_admin_bar
 	 */
 	function tailor_admin_bar_edit_link( $wp_admin_bar ) {
-		
+
 		if ( tailor()->is_canvas() ) {
 			return;
 		}
@@ -81,4 +81,53 @@ if ( ! function_exists( 'tailor_inline_edit_link' ) ) {
 
 	add_filter( 'page_row_actions', 'tailor_inline_edit_link', 10, 2 );
 	add_filter( 'post_row_actions', 'tailor_inline_edit_link', 10, 2 );
+}
+
+if ( ! function_exists( 'tailor_content_editor_link' ) ) {
+
+    /**
+     * Adds an edit link above content editor, next to the 'Add Media' button
+     *
+     * @since 1.5.4
+     */
+    function tailor_content_editor_link() {
+
+		if ( tailor()->is_canvas() ) {
+			return;
+		}
+
+		// Only add the Admin Bar link when editing a post or page
+		if ( is_admin() ) {
+
+			$screen = get_current_screen();
+			if ( 'post' !== $screen->base ) {
+				return;
+			}
+		}
+
+		// Do not display link on archive pages
+		else if ( ! is_singular() ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post || 'auto-draft' == get_post_status( $post->ID ) ) {
+			return;
+		}
+
+		if ( tailor()->check_user_role() && tailor()->check_post( $post ) ) {
+
+			$post_type_object = get_post_type_object( get_post_type( $post ) );
+
+			$link = array(
+				'href'  => tailor()->get_edit_url( $post->ID ),
+				'id'    => 'edit-with-tailor',
+				'title' => sprintf( __( 'Tailor this %s', 'tailor' ), $post_type_object->labels->singular_name ),
+			);
+
+			echo vsprintf( '<a href="%s" id="%s" class="button">%s</a>', $link );
+		}
+	}
+
+	add_action( 'media_buttons', 'tailor_content_editor_link', 99 );
 }


### PR DESCRIPTION
Addresses issue #23 

Added a function which inserts a "Tailor this `post-type`" button above the standard WordPress content editor, next to the "Add Media" button.

Uses the same checks found in the related function for adding an edit link to the Admin Bar.

PHPDoc `@since` field may need to be altered depending on your current working version. I've assumed a patch from the current version (`1.5.3 -> 1.5.4`)