### PR TITLE
Admin notice should allow html text.

### DIFF
--- a/partials/admin/html/notice-tailored-content.php
+++ b/partials/admin/html/notice-tailored-content.php
@@ -22,7 +22,7 @@ $alert_text = sprintf(
 ); ?>
 
 <div class="notice notice-warning is-dismissible">
-	<p><?php esc_html_e( $alert_text ); ?></p>
+	<p><?php _e( $alert_text ); ?></p>
 	<button type="button" class="notice-dismiss">
 		<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'tailor' ); ?></span>
 	</button>


### PR DESCRIPTION
The backend notice on a "tailored" page is a little bit incomprehensible for final users. If we want to provide more precise informations about the tailored page process, we have to add some html markup. There is no reason that this notice should escape html.