### PR TITLE
Use global-primary-color for carousel navigation.

### DIFF
--- a/assets/css/scss/vendor/_slick.scss
+++ b/assets/css/scss/vendor/_slick.scss
@@ -112,7 +112,7 @@ $slick-border-color: $border-color !default;
 		outline: none;
 		border: 1px solid $border-color;
 		background-color: #fff;
-		color: #0f95ee;
+		color: $global-primary-color;
 		border-radius: 2px;
 		opacity: 0;
 
@@ -212,7 +212,7 @@ $slick-border-color: $border-color !default;
 					top: -2px;
 					left: -2px;
 					border-radius: 100%;
-					background-color: #0f95ee;
+					background-color: $global-primary-color;
 					opacity: 0;
 					transition: -webkit-transform 700ms cubic-bezier(0.19, 1, -1.78, 1) 0ms, background 500ms cubic-bezier(0.19, 1, 0.22, 1) 0ms, opacity 700ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 					transition: transform 700ms cubic-bezier(0.19, 1, 0.22, 1) 0ms, background 500ms cubic-bezier(0.19, 1, 0.22, 1) 0ms, opacity 350ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;


### PR DESCRIPTION
To unify navigation elements, this hex value shouldn't be hard written.