### PR TITLE
save content as shortcodes instead of HTML

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -353,6 +353,24 @@ class Tailor_Settings {
 			)
 		);
 
+		$raw_shortcode_field_id = 'raw_shortcode';
+		$raw_shortcode_field_label = __( 'Save content as shortcode', 'tailor' );
+		add_settings_field(
+			$raw_shortcode_field_id,
+			$raw_shortcode_field_label,
+			array( $this, 'render_field' ),
+			$setting_id,
+			$setting_id . '_features',
+			array(
+				'type'              =>  'checkbox',
+				'name'              =>  $setting_id . '[' . $raw_shortcode_field_id . ']',
+				'value'             =>  tailor_get_setting( $raw_shortcode_field_id ),
+				'options'           =>  array(
+					'on'                =>  __( 'Save your content as shortcode tags instead of HTML.', 'tailor' )
+				),
+			)
+		);
+
 		/**
 		 * Fires after the admin setting sections and fields have been registered.
 		 *

--- a/includes/class-models.php
+++ b/includes/class-models.php
@@ -574,6 +574,8 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 	    public function update_post_content( $post_id, $sanitized_models ) {
 		    $post = get_post( $post_id );
 		    $updated_post_content = '';
+	    	$settings = get_option( TAILOR_SETTING_ID );
+		    $setting_raw_shortcode = $settings['raw_shortcode']['on'];
 		    
 		    // Generate the page content using the model collection
 		    if ( ! empty( $sanitized_models ) ) {
@@ -590,7 +592,12 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 			    }
 			    
 			    $shortcode_tags = $dynamic_shortcodes;
-			    $updated_post_content = do_shortcode( $shortcodes );
+
+			    if ( $setting_raw_shortcode === 'on' ) {
+			    	$updated_post_content = $shortcodes;
+			    } else {
+			    	$updated_post_content = do_shortcode( $shortcodes );
+			    }
 		    }
 
 		    /**


### PR DESCRIPTION
made a pull request based on this suggestion, https://support.gettailor.com/hc/en-us/community/posts/218805128-Save-as-shortcode-in-DB
don't know if doing it the right way since I'm not that familiar with git sorry if it's wrong.
