### PR TITLE
Improve priority order

### DIFF
--- a/includes/class-panels.php
+++ b/includes/class-panels.php
@@ -216,6 +216,7 @@ if ( ! class_exists( 'Tailor_Panels' ) ) {
 
 		    // Prepare panels
 		    $panels = array();
+            $this->panels = array_reverse($this->panels);
 		    uasort( $this->panels, array( $this, '_cmp_priority' ) );
 		    foreach ( $this->panels as $panel ) {  /* @var $panel Tailor_Panel */
 
@@ -227,6 +228,7 @@ if ( ! class_exists( 'Tailor_Panels' ) ) {
 
 		    // Prepare sections
 		    $sections = array();
+            $this->sections = array_reverse($this->sections);
 		    uasort( $this->sections, array( $this, '_cmp_priority' ) );
 		    foreach ( $this->sections as $section ) {  /* @var $section Tailor_Section */
 
@@ -242,6 +244,7 @@ if ( ! class_exists( 'Tailor_Panels' ) ) {
 
 		    // Prepare controls
 		    $controls = array();
+            $this->controls = array_reverse($this->controls);
 		    uasort( $this->controls, array( $this, '_cmp_priority' ) );
 		    foreach ( $this->controls as $control ) {  /* @var $control Tailor_Control */
 

--- a/includes/elements/abstract-element.php
+++ b/includes/elements/abstract-element.php
@@ -321,6 +321,7 @@ if ( class_exists( 'Tailor_Setting_Manager' ) && ! class_exists( 'Tailor_Element
 
 		    // Prepare panels
 		    $panels = array();
+            $this->panels = array_reverse($this->panels);
 		    uasort( $this->panels, array( $this, '_cmp_priority' ) );
 		    foreach ( $this->panels as $panel ) {  /* @var $panel Tailor_Panel */
 
@@ -332,6 +333,7 @@ if ( class_exists( 'Tailor_Setting_Manager' ) && ! class_exists( 'Tailor_Element
 
 		    // Prepare sections
 		    $sections = array();
+            $this->sections = array_reverse($this->sections);
 		    uasort( $this->sections, array( $this, '_cmp_priority' ) );
 		    foreach ( $this->sections as $section ) {  /* @var $section Tailor_Section */
 
@@ -350,6 +352,7 @@ if ( class_exists( 'Tailor_Setting_Manager' ) && ! class_exists( 'Tailor_Element
 
 		    // Prepare controls
 		    $controls = array();
+            $this->controls = array_reverse($this->controls);
 		    uasort( $this->controls, array( $this, '_cmp_priority' ) );
 		    foreach ( $this->controls as $control ) {  /* @var $control Tailor_Control */
 


### PR DESCRIPTION
Currently when we add two controls, panels, or sections with the same priority value, the last one will goes to top. To make it ordered correctly the array should be reversed first before sorting.