### PR TITLE
Prevent error if get_current_screen() not defined

### DIFF
--- a/includes/helpers/helpers-hooks.php
+++ b/includes/helpers/helpers-hooks.php
@@ -173,6 +173,9 @@ if ( ! function_exists( 'tailor_content_editor_link' ) ) {
 
 		// Only add the Admin Bar link when editing a post or page
 		if ( is_admin() ) {
+			if ( ! function_exists( 'get_current_screen' ) ) {
+				return;			
+			}
 			$screen = get_current_screen();
 			if ( 'post' !== $screen->base ) {
 				return;


### PR DESCRIPTION
I ran into a conflict with another plugin (Carbon Fields) that caused a fatal error because  get_current_screen() was not defined when attempting to add the edit link above content editor.  I did further research and found that, per the WordPress Codex, get_current_screen() is defined on most admin pages, but not all. Thus there are cases where is_admin() will return true, but attempting to call get_current_screen() will result in a fatal error because it is not defined... Checking that the function exists before calling it allows us to avoid this error in general, but we can no longer be sure that we are editing a post or page and can only assume that we are not.