### PR TITLE
Set 'posts_per_page' to -1 to allow unlimited gallery images

### DIFF
--- a/includes/shortcodes/shortcode-gallery.php
+++ b/includes/shortcodes/shortcode-gallery.php
@@ -64,6 +64,7 @@ if ( ! function_exists( 'tailor_shortcode_gallery' ) ) {
 		    $q = new WP_Query( array(
 			    'post_type'             =>  'attachment',
 			    'post_status'           =>  'any',
+			    'posts_per_page'        =>  -1,
 			    'post__in'              =>  explode( ',', $atts['ids'] ),
 			    'orderby'               =>  'post__in',
 		    ) );


### PR DESCRIPTION
Having more than 10 images in a Tailor Gallery element will not work at the moment. This is because the default for a WP_Query is set to 10.

Setting ```posts_per_page => -1``` allows for unlimited images in a single gallery. If you wish to cap the value at for example 100 please feel free to change this.