### PR TITLE
Add "Autoplay Speed" field to Slick Slider-based elements

### DIFF
--- a/assets/js/src/canvas/components/ui/carousel-simple.js
+++ b/assets/js/src/canvas/components/ui/carousel-simple.js
@@ -24,6 +24,7 @@ Carousel = Components.create( {
 			slidesToShow : 1,
 			slidesToScroll : 1,
 			autoplay : false,
+			autoplaySpeed : 3000,
 			arrows : false,
 			dots : true,
 			fade : false

--- a/assets/js/src/canvas/components/ui/carousel.js
+++ b/assets/js/src/canvas/components/ui/carousel.js
@@ -23,6 +23,7 @@ Carousel = Components.create( {
 			slidesToScroll : 1,
 			initialSlide : 0,
 			autoplay : false,
+			autoplaySpeed : 3000,
 			arrows : false,
 			dots : false,
 			fade : false,
@@ -76,6 +77,7 @@ Carousel = Components.create( {
 		var currentIndex = this.$dots.filter( function() { return this.getAttribute( 'data-id' ) == currentSlide; } ).index();
 		var options = $.extend( {}, this.options, {
 			autoplay : false,
+			autoplaySpeed : 3000,
 			fade : false,
 			initialSlide : currentIndex
 		} );

--- a/assets/js/src/canvas/preview/behaviors.js
+++ b/assets/js/src/canvas/preview/behaviors.js
@@ -4,6 +4,7 @@
 		var carousel = this;
 		var options = {
 			autoplay : '1' == atts.autoplay,
+			autoplaySpeed : 3000 == atts.autoplay_speed,
 			arrows : '1' == atts.arrows,
 			dots : false,
 			fade : '1' == atts.fade && '1' == atts.items_per_row,
@@ -31,6 +32,7 @@
 		if ( 'carousel' == atts.layout ) {
 			options = {
 				autoplay : '1' == atts.autoplay,
+				autoplaySpeed : 3000 == atts.autoplay_speed,
 				arrows : '1' == atts.arrows,
 				dots : '1' == atts.dots,
 				fade : ( '1' == atts.fade && '1' == atts.items_per_row ),
@@ -43,6 +45,7 @@
 		else if ( 'slideshow' == atts.layout ) {
 			options = {
 				autoplay : '1' == atts.autoplay,
+				autoplaySpeed : 3000 == atts.autoplay_speed,
 				arrows : '1' == atts.arrows,
 				dots : false,
 				fade : true,
@@ -85,6 +88,7 @@
 		if ( 'carousel' == atts.layout ) {
 			options = {
 				autoplay : '1' == atts.autoplay,
+				autoplaySpeed : 3000 == atts.autoplay_speed,
 				arrows : '1' == atts.arrows,
 				dots : '1' == atts.dots,
 				fade : ( '1' == atts.fade && '1' == atts.items_per_row ),

--- a/assets/js/src/canvas/preview/behaviors.js
+++ b/assets/js/src/canvas/preview/behaviors.js
@@ -4,7 +4,7 @@
 		var carousel = this;
 		var options = {
 			autoplay : '1' == atts.autoplay,
-			autoplaySpeed : 3000 == atts.autoplay_speed,
+			autoplaySpeed : atts.autoplay_speed,
 			arrows : '1' == atts.arrows,
 			dots : false,
 			fade : '1' == atts.fade && '1' == atts.items_per_row,
@@ -32,7 +32,7 @@
 		if ( 'carousel' == atts.layout ) {
 			options = {
 				autoplay : '1' == atts.autoplay,
-				autoplaySpeed : 3000 == atts.autoplay_speed,
+				autoplaySpeed : atts.autoplay_speed,
 				arrows : '1' == atts.arrows,
 				dots : '1' == atts.dots,
 				fade : ( '1' == atts.fade && '1' == atts.items_per_row ),
@@ -45,7 +45,7 @@
 		else if ( 'slideshow' == atts.layout ) {
 			options = {
 				autoplay : '1' == atts.autoplay,
-				autoplaySpeed : 3000 == atts.autoplay_speed,
+				autoplaySpeed : atts.autoplay_speed,
 				arrows : '1' == atts.arrows,
 				dots : false,
 				fade : true,
@@ -88,7 +88,7 @@
 		if ( 'carousel' == atts.layout ) {
 			options = {
 				autoplay : '1' == atts.autoplay,
-				autoplaySpeed : 3000 == atts.autoplay_speed,
+				autoplaySpeed : atts.autoplay_speed,
 				arrows : '1' == atts.arrows,
 				dots : '1' == atts.dots,
 				fade : ( '1' == atts.fade && '1' == atts.items_per_row ),

--- a/assets/js/src/frontend.js
+++ b/assets/js/src/frontend.js
@@ -86,6 +86,7 @@ window.Tailor = {
 			var $data = $el.data() || {};
 			var options = {
 				autoplay : $data.autoplay || false,
+				autoplaySpeed : $data.autoplaySpeed || 3000,
 				arrows : $data.arrows || false,
 				draggable : true
 			};

--- a/assets/js/src/frontend/components/ui/carousel.js
+++ b/assets/js/src/frontend/components/ui/carousel.js
@@ -40,6 +40,7 @@ Carousel.prototype = {
         slidesToShow : 1,
         slidesToScroll : 1,
         autoplay : false,
+        autoplaySpeed : 3000,
         arrows : false,
         dots : false,
         fade : false,

--- a/assets/js/src/shared/components/ui/slideshow.js
+++ b/assets/js/src/shared/components/ui/slideshow.js
@@ -24,6 +24,7 @@ Slideshow = Components.create( {
             slidesToShow : 1,
             slidesToScroll : 1,
             autoplay : false,
+            autoplaySpeed : 3000,
             arrows : false,
             dots : false,
             fade : true

--- a/includes/controls/class-input-group.php
+++ b/includes/controls/class-input-group.php
@@ -3,7 +3,7 @@
 /**
  * Tailor Input Group Control class.
  *
- * @package Tailor Advanced
+ * @package Tailor
  * @subpackage Controls
  * @since 1.0.0
  */

--- a/includes/elements/class-carousel.php
+++ b/includes/elements/class-carousel.php
@@ -59,6 +59,7 @@ if ( class_exists( 'Tailor_Element' ) && ! class_exists( 'Tailor_Carousel_Elemen
 		        'min_item_height_tablet',
 		        'min_item_height_mobile',
 		        'autoplay',
+		        'autoplay_speed',
 		        'fade',
 		        'arrows',
 		        'dots',
@@ -83,6 +84,17 @@ if ( class_exists( 'Tailor_Element' ) && ! class_exists( 'Tailor_Carousel_Elemen
 		        'autoplay'              =>  array(
 			        'control'               =>  array(
 				        'description'           =>  __( 'This will only take effect in the frontend', 'tailor' ),
+			        ),
+		        ),
+		        'autoplay_speed'              =>  array(
+			        'control'               =>  array(
+				        'description'           =>  __( 'This will only take effect in the frontend', 'tailor' ),
+				        'dependencies'          =>  array(
+					        'autoplay'              =>  array(
+						        'condition'             =>  'equals',
+						        'value'                 =>  '1',
+					        ),
+				        ),
 			        ),
 		        ),
 		        'fade'                  =>  array(

--- a/includes/elements/class-gallery.php
+++ b/includes/elements/class-gallery.php
@@ -60,6 +60,7 @@ if ( class_exists( 'Tailor_Element' ) && ! class_exists( 'Tailor_Gallery_Element
 		        'items_per_row',
 		        'item_spacing',
 		        'autoplay',
+		        'autoplay_speed',
 		        'arrows',
 		        'dots',
 		        'thumbnails',
@@ -127,6 +128,20 @@ if ( class_exists( 'Tailor_Element' ) && ! class_exists( 'Tailor_Gallery_Element
 					        'layout'                =>  array(
 						        'condition'             =>  'contains',
 						        'value'                 =>  array( 'carousel', 'slideshow' ),
+					        ),
+				        ),
+			        ),
+		        ),
+		        'autoplay_speed'        =>  array(
+			        'control'               =>  array(
+				        'dependencies'          =>  array(
+					        'layout'                =>  array(
+						        'condition'             =>  'contains',
+						        'value'                 =>  array( 'carousel', 'slideshow' ),
+					        ),
+					        'autoplay'              =>  array(
+						        'condition'             =>  'equals',
+						        'value'                 =>  '1',
 					        ),
 				        ),
 			        ),

--- a/includes/elements/class-posts.php
+++ b/includes/elements/class-posts.php
@@ -56,6 +56,7 @@ if ( class_exists( 'Tailor_Element' ) && ! class_exists( 'Tailor_Posts_Element' 
 		        'items_per_row',
 		        'item_spacing',
 		        'autoplay',
+		        'autoplay_speed',
 		        'arrows',
 		        'dots',
 		        'fade',
@@ -124,6 +125,20 @@ if ( class_exists( 'Tailor_Element' ) && ! class_exists( 'Tailor_Posts_Element' 
 					        'layout'                =>  array(
 						        'condition'             =>  'contains',
 						        'value'                 =>  array( 'carousel', 'slideshow' ),
+					        ),
+				        ),
+			        ),
+		        ),
+		        'autoplay_speed'        =>  array(
+			        'control'               =>  array(
+				        'dependencies'          =>  array(
+					        'layout'                =>  array(
+						        'condition'             =>  'contains',
+						        'value'                 =>  array( 'carousel', 'slideshow' ),
+					        ),
+					        'autoplay'              =>  array(
+						        'condition'             =>  'equals',
+						        'value'                 =>  '1',
 					        ),
 				        ),
 			        ),

--- a/includes/helpers/helpers-elements.php
+++ b/includes/helpers/helpers-elements.php
@@ -420,6 +420,18 @@ if ( ! function_exists( 'tailor_control_presets' ) ) {
 					'section'                   =>  'general',
 				),
 			),
+			'autoplay_speed'            =>  array(
+				'setting'                   =>  array(
+					'sanitize_callback'         =>  'tailor_sanitize_number',
+					'default'                   =>  '3000',
+				),
+				'control'                   =>  array(
+					'label'                     =>  __( 'Autoplay Speed', 'tailor' ),
+					'description'               =>  'In milliseconds',
+					'type'                      =>  'number',
+					'section'                   =>  'general',
+				),
+			),
 			'fade'                      =>  array(
 				'setting'                   =>  array(
 					'sanitize_callback'         =>  'tailor_sanitize_text',

--- a/includes/helpers/helpers-markup.php
+++ b/includes/helpers/helpers-markup.php
@@ -80,6 +80,7 @@ if ( ! function_exists( 'tailor_filter_allowed_html' ) ) {
 		if ( 'post' == $context ) {
 			$allowed['div']['data-slides'] = true;
 			$allowed['div']['data-autoplay'] = true;
+			$allowed['div']['data-autoplay-speed'] = true;
 			$allowed['div']['data-arrows'] = true;
 			$allowed['div']['data-dots'] = true;
 			$allowed['div']['data-fade'] = true;

--- a/includes/shortcodes/shortcode-carousel.php
+++ b/includes/shortcodes/shortcode-carousel.php
@@ -36,6 +36,7 @@ if ( ! function_exists( 'tailor_shortcode_carousel' ) ) {
 	    $data = array(
 		    'slides'            =>  $items_per_row,
 		    'autoplay'          =>  boolval( $atts['autoplay'] ) ? 'true' : 'false',
+		    'autoplay-speed'    =>  intval( $atts['autoplay_speed'] ) ? intval( $atts['autoplay_speed'] ) : 3000,
 		    'arrows'            =>  boolval( $atts['arrows'] ) ? 'true' : 'false',
 		    'dots'              =>  boolval( $atts['dots'] ) ? 'true' : 'false',
 		    'fade'              =>  boolval( $atts['fade'] && '1' == $items_per_row ) ? 'true' : 'false',

--- a/includes/shortcodes/shortcode-gallery.php
+++ b/includes/shortcodes/shortcode-gallery.php
@@ -55,6 +55,7 @@ if ( ! function_exists( 'tailor_shortcode_gallery' ) ) {
 		    $data = array(
 			    'slides'            =>  $items_per_row,
 			    'autoplay'          =>  boolval( $atts['autoplay'] ) ? 'true' : 'false',
+			    'autoplay-speed'    =>  intval( $atts['autoplay_speed'] ) ? intval( $atts['autoplay_speed'] ) : 3000,
 			    'arrows'            =>  boolval( $atts['arrows'] ) ? 'true' : 'false',
 			    'dots'              =>  $dots ? 'true' : 'false',
 			    'thumbnails'        =>  boolval( $atts['thumbnails'] ) ? 'true' : 'false',

--- a/includes/shortcodes/shortcode-posts.php
+++ b/includes/shortcodes/shortcode-posts.php
@@ -36,6 +36,7 @@ if ( ! function_exists( 'tailor_shortcode_posts' ) ) {
 	    $data = array(
 		    'slides'            =>  $items_per_row,
 		    'autoplay'          =>  boolval( $atts['autoplay'] ) ? 'true' : 'false',
+		    'autoplay-speed'    =>  intval( $atts['autoplay_speed'] ) ? intval( $atts['autoplay_speed'] ) : 3000,
 		    'arrows'            =>  boolval( $atts['arrows'] ) ? 'true' : 'false',
 		    'dots'              =>  boolval( $atts['dots'] ) ? 'true' : 'false',
 		    'fade'              =>  boolval( $atts['fade'] && '1' == $items_per_row ) ? 'true' : 'false',


### PR DESCRIPTION
Hi Andrew,

I’ve added an input field to adjust the slide "pause" duration for all Slick Slider-based elements:
- Carousel
- Gallery (Carousel and Slideshow layout)
- Posts (Carousel layout)

“Autoplay Speed” field is displayed conditionally when "Autoplay" is set to `on`. "Autoplay Speed" is in milliseconds.

I wasn’t sure what your preferred PR process was because I couldn’t find any contributing guidelines, so I only committed un-compiled (src) files… if you need anything else let me know.

Great project, very clean codebase — I hope to commit more in the future! 🙂