### PR TITLE
Updated tailor_get_users query

### DIFF
--- a/includes/helpers/helpers-general.php
+++ b/includes/helpers/helpers-general.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'tailor_get_users' ) ) {
 	 * @return array
 	 */
 	function tailor_get_users() {
-		$blogusers = get_users();
+		$blogusers = get_users( array( 'fields' => array( 'ID', 'display_name' ) ) );
 		$user_ids = array();
 		$user_ids[0] = __( 'Current user', 'tailor' );
 


### PR DESCRIPTION
Have been having some problem with to many queries when you get alot of users on your WordPress site so I updated helpers-general.php with a more specific query for get_users. Instead of fetching the whole table I'm just fetching ID & display_name.

As of this support post:
https://support.gettailor.com/hc/en-us/community/posts/115000498647-Too-many-database-queries-crashed-my-page-?page=1#community_comment_115000606927