### PR TITLE
Expose $args in tailor_partial filter and tailor_partial_* action

### DIFF
--- a/actions.md
+++ b/actions.md
@@ -12,7 +12,7 @@
 | tailor_save_after | Fires after all save actions have been completed | int $post_id <br> Tailor $tailor |
 | tailor_save_post_content | Fires before the updated post content is saved | int $post_id <br> string $post_content <br> string $updated_post_content |
 | tailor_save_post_content_after | Fires after the updated post content has been saved | int $post_id <br> string $post_content <br> string $updated_post_content |
-| tailor\_partial\_**{$slug}** | Fires before a template partial is loaded | string $partial <br> string $slug <br> string $name |
+| tailor\_partial\_**{$slug}** | Fires before a template partial is loaded | string $partial <br> string $slug <br> string $name <br> array $args |
 
 ## Element actions
 

--- a/filters.md
+++ b/filters.md
@@ -135,7 +135,7 @@
 |----------|----------|----------|
 | tailor_theme_partial_dir | Applies to theme directory to be searched for Tailor template partials | string $theme_partial_dir |
 | tailor_plugin_partial_paths | Applies to plugin directories to be searched for Tailor template partials | string $plugin_partial_paths |
-| tailor_partial | Applies to template partial that is about to be loaded | string $partial <br> string $slug <br> string $name |
+| tailor_partial | Applies to template partial that is about to be loaded | string $partial <br> string $slug <br> string $name <br> array $args |
 | tailor_excerpt | Applies to excerpt used in elements | string $trimmed_excerpt <br> string $excerpt <br> int $excerpt_length <br> string $excerpt_more |
 | tailor_post_meta_order | Applies to order of post meta displayed in the Posts element | array $meta_order |
 | tailor_show_comments_link | Allow developers to control whether the comment number should act as a link | bool |

--- a/includes/helpers/helpers-markup.php
+++ b/includes/helpers/helpers-markup.php
@@ -147,8 +147,9 @@ if ( ! function_exists( 'tailor_partial' ) ) {
 		 * @param string $partial
 		 * @param string $slug
 		 * @param string $name
+		 * @param array $args
 		 */
-		$partial = apply_filters( 'tailor_partial', $partial, $slug, $name );
+		$partial = apply_filters( 'tailor_partial', $partial, $slug, $name, $args );
 
 		if ( $partial ) {
 
@@ -160,8 +161,9 @@ if ( ! function_exists( 'tailor_partial' ) ) {
 			 * @param string $partial
 			 * @param string $slug
 			 * @param string $name
+			 * @param array $args
 			 */
-			do_action( "tailor_partial_{$slug}", $partial, $slug, $name );
+			do_action( "tailor_partial_{$slug}", $partial, $slug, $name, $args );
 
 			if ( $args && is_array( $args ) ) {
 				extract( $args );


### PR DESCRIPTION
This would be useful so one can hook in alternative template engines, in my case I'd like to render the templates through Twig/Timber. People using Sage and Blade would probably find it useful as well.

Technically only the filter change is necessary but seems appropriate that both the filter and the action have matching arguments.