### PR TITLE
Tweak to fix performance of calling tailor_get_terms()

### DIFF
--- a/includes/class-widgets.php
+++ b/includes/class-widgets.php
@@ -20,6 +20,16 @@ if ( ! class_exists( 'Tailor_Widgets' ) ) {
     class Tailor_Widgets {
 
         /**
+         * @var Cache categories
+         */
+        public static $categories;
+
+        /**
+         * @var Cache tags
+         */
+        public static $post_tags;
+
+        /**
          * Constructor.
          *
          * @since 1.6.0
@@ -48,7 +58,13 @@ if ( ! class_exists( 'Tailor_Widgets' ) ) {
 	     * @param Tailor_Elements $element_manager
 	     */
 	    public function register_widgets( $element_manager ) {
-		    global $wp_widget_factory;
+	        // read and cache the categories and post tags to save on performance.
+            // previously we did this for every element which is heavy if there are many elements and
+            // many categories/tags
+	        self::$categories = tailor_get_terms();
+	        self::$post_tags = tailor_get_terms('post_tag');
+
+	        global $wp_widget_factory;
 		    foreach ( $wp_widget_factory->widgets as $widget_class_name => $wp_widget ) {
 			    
 			    if ( ! array_key_exists( 'description', $wp_widget->widget_options ) ) {

--- a/includes/helpers/helpers-elements.php
+++ b/includes/helpers/helpers-elements.php
@@ -1,5 +1,7 @@
 <?php
 
+//include_once '../class-widgets.php';
+
 /**
  * Element helper functions.
  *
@@ -562,7 +564,7 @@ if ( ! function_exists( 'tailor_control_presets' ) ) {
 				'control'                   =>  array(
 					'label'                     =>  __( 'Categories', 'tailor' ),
 					'type'                      =>  'select-multi',
-					'choices'                   =>  tailor_get_terms(),
+					'choices'                   =>  Tailor_Widgets::$categories,
 					'section'                   =>  'query',
 				),
 			),
@@ -573,7 +575,7 @@ if ( ! function_exists( 'tailor_control_presets' ) ) {
 				'control'                   =>  array(
 					'label'                     =>  __( 'Tags', 'tailor' ),
 					'type'                      =>  'select-multi',
-					'choices'                   =>  tailor_get_terms( 'post_tag' ),
+					'choices'                   =>  Tailor_Widgets::$post_tags,
 					'section'                   =>  'query',
 				),
 			),


### PR DESCRIPTION
Tweak to fix performance of calling tailor_get_terms() for each element. Instead call it once on registration and cache the result in static variables