### PR TITLE
Show post meta data when only one item is selected

### DIFF
--- a/partials/meta-post.php
+++ b/partials/meta-post.php
@@ -24,7 +24,7 @@ $meta_order = array( 'author', 'date', 'category', 'tag', 'comment-number' );
  */
 apply_filters( 'tailor_post_meta_order', $meta_order );
 
-if ( count( array_intersect( $meta, $meta_order ) ) > 1 ) {
+if ( count( array_intersect( $meta, $meta_order ) ) >= 1 ) {
 
 	echo '<div class="entry__meta">';
 


### PR DESCRIPTION
Currently the default meta (excerpt and date) will result in the date not getting displayed because `>` should be `>=` to allow for only one meta type.